### PR TITLE
feat: include call start time in response and metadata

### DIFF
--- a/apps/socket/src/call/call.gateway.ts
+++ b/apps/socket/src/call/call.gateway.ts
@@ -355,11 +355,16 @@ export class CallGateway
         callType: callType,
         callMode: callMode,
         callId: history.call_id,
+        startedAt: history.started_at,
       };
       this.io.to(otherMembers).emit('call:request', historyCall);
       this.io.to(roomClients).emit(socketEvent.MSGUPSERT, msg);
 
-      return { ok: true, room: { room_id: room.room_id } };
+      return {
+        ok: true,
+        room: { room_id: room.room_id },
+        startedAt: history.started_at,
+      };
     } catch (error) {
       this.logger.error('[CALL] Error starting call:', error);
       client.emit('error', {

--- a/libs/grpc/chat.proto
+++ b/libs/grpc/chat.proto
@@ -512,10 +512,11 @@ message outputCall {
 }
 
 message CallMetadata {
-  CallHistory history = 1;      
-  RoomResponse room = 2;         
-  string callType = 3;  
-  MessageCore msg=4;   
+  CallHistory history = 1;
+  RoomResponse room = 2;
+  string callType = 3;
+  MessageCore msg=4;
+  string callMode = 5;
 }
 
 message Member {


### PR DESCRIPTION
Add `startedAt` field to the call response and update `CallMetadata` in the `chat.proto` file to include `callMode`. This change enhances the call history information, providing more details about when a call starts, which can be useful for logging and analytics purposes. It also ensures that all metadata attributes related to calls are properly communicated between services.