### PR TITLE
fix(chat): cast roomInfo._id sang ObjectId trong getMsgFromRoom aggre…

### DIFF
--- a/apps/chat/src/handle-chat/handle-chat.service.ts
+++ b/apps/chat/src/handle-chat/handle-chat.service.ts
@@ -1206,7 +1206,17 @@ export class HandleChatService implements OnModuleInit {
           type === 'new' ? { $gt: cursorTs } : { $lt: cursorTs };
       }
     }
-
+    // const compare: Record<string, any> = {};
+    // if (type && msgId && Types.ObjectId.isValid(msgId)) {
+    //   const msgObjectId = this.utils.convertToObjectIdMongoose(msgId);
+    //   if (type === 'new') {
+    //     // Load tin nhắn mới hơn msgId (để load real-time updates)
+    //     compare._id = { $gt: msgObjectId };
+    //   } else if (type === 'old') {
+    //     // Load tin nhắn cũ hơn msgId (để pagination lùi về quá khứ)
+    //     compare._id = { $lt: msgObjectId };
+    //   }
+    // }
     // LUÔN lấy N tin MỚI NHẤT của tập đã lọc: DESC + limit rồi đảo về ASC cho FE.
     // - type='new' (createdAt > cursor): N tin MỚI NHẤT sau cursor → mở phòng hiện
     //   ĐÚNG tin mới nhất kể cả cache cũ (gap giữa cursor↔mới nhất tải sau bằng
@@ -1214,10 +1224,18 @@ export class HandleChatService implements OnModuleInit {
     // - type='old' (createdAt < cursor): N tin gần nhất trong quá khứ (pagination lùi).
     // - null: N tin mới nhất toàn phòng.
     const pipeLine = buildMessageCorePipeline(userId);
+
     const result = await this.messageModel.aggregate([
       {
         $match: {
-          msg_roomId: roomInfo._id,
+          // PHẢI cast về ObjectId: `roomInfo._id` có thể là STRING khi room phục
+          // vụ từ cache L2 (Redis JSON-deserialize _id → string). Aggregate
+          // KHÔNG auto-cast như query Mongoose → `{msg_roomId: "<hex>"}` (string)
+          // sẽ KHÔNG khớp `msg_roomId` (ObjectId) → trả RỖNG dù DB có data.
+          // (createMessage ghi qua Mongoose nên được cast, vẫn lưu đúng.)
+          msg_roomId: this.utils.convertToObjectIdMongoose(
+            String(roomInfo._id),
+          ),
           ...compare,
         },
       },


### PR DESCRIPTION
…gate

Bug: getMsgFromRoom trả metadata:[] dù DB CÓ tin (đã verify: raw match
{msg_roomId: ObjectId(<room>)} trả 61 tin).

Root cause: `roomInfo` lấy từ RoomCacheRepository (cache 2 tầng). Khi phục vụ từ L2 (Redis), EntityCacheService JSON-deserialize → `roomInfo._id` thành STRING. `aggregate` của Mongoose KHÔNG auto-cast schema như query thường, nên `$match: { msg_roomId: roomInfo._id }` so STRING với field ObjectId → KHÔNG khớp → rỗng. createMessage ghi `msg_roomId: finInfo._id` qua Mongoose (được cast) nên vẫn lưu đúng ObjectId → "tạo được mà đọc rỗng". Chập chờn: L1 (60s, giữ ObjectId sau DB-load) chạy đúng; hết L1 → L2 trả string → hỏng.

Fix: msg_roomId: convertToObjectIdMongoose(String(roomInfo._id)) — đúng cho cả khi _id là string (L2) lẫn ObjectId (L1/DB). Gỡ console.log debug.

Các aggregate khác đã an toàn (buildMessageDetailPipeline cast msgId nội bộ; recomputeUnread dùng convertToObjectIdMongoose; getOneMsg cast msgId).