### PR TITLE
fix: tóm tắt file AI + đẩy summary realtime + scope kết quả tìm kiếm

### DIFF
--- a/apps/ai/src/ai.controller.ts
+++ b/apps/ai/src/ai.controller.ts
@@ -1,20 +1,23 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Inject, Logger } from '@nestjs/common';
 import { AIService } from './ai.service';
-import { GrpcMethod, MessagePattern } from '@nestjs/microservices';
+import { ClientKafka, GrpcMethod, MessagePattern } from '@nestjs/microservices';
 import { EmbeddingService } from './embedding.service';
 import { KafkaEvent } from '@app/dto/enum.type';
 import { SearchMessagesDto } from '@app/dto/ai.dto';
 import type { MulterFile } from '@app/dto';
-import { AiLogUseService } from './ai-log-use.service';
+import { AiLogUseService, AI_KAFKA_CLIENT } from './ai-log-use.service';
 import type { AiLogUsagePayload } from './ai-log-use.service';
+import Utils from '@app/helpers/utils';
 import { map } from 'rxjs/operators';
 
 @Controller()
 export class AIController {
+  private readonly logger = new Logger(AIController.name);
   constructor(
     private readonly service: AIService,
     private readonly embeddingService: EmbeddingService,
     private readonly aiLogUseService: AiLogUseService,
+    @Inject(AI_KAFKA_CLIENT) private readonly kafkaClient: ClientKafka,
   ) {}
 
   @GrpcMethod('AIService', 'Moderation')
@@ -60,14 +63,56 @@ export class AIController {
     mimeType: string;
     messageId: string;
   }) {
-    return await this.embeddingService.createEmbedding({
-      text: data.fileUrl,
+    // 1. Tóm tắt THẬT nội dung file (tải file từ URL rồi cho AI tóm tắt).
+    //    Trước đây hàm này nhét thẳng `fileUrl` làm text embedding → pipeline
+    //    getMsg đọc ra "summary" chính là cái link, nên FE chỉ thấy link chứ
+    //    không có tóm tắt. Giờ embed nội dung tóm tắt thật.
+    let summaryText = '';
+    try {
+      const res: any = await this.service.summaryDocument(
+        'file_url',
+        undefined,
+        data.fileUrl,
+        null,
+        data.userId,
+      );
+      summaryText = String(res?.metadata?.summary ?? '').trim();
+    } catch (err) {
+      this.logger.error(
+        `summaryDocument failed for attachment ${data.docId}`,
+        err as Error,
+      );
+    }
+
+    // Không tóm tắt được → KHÔNG lưu link làm summary (đó chính là bug cũ).
+    if (!summaryText) {
+      this.logger.warn(
+        `Empty summary for attachment ${data.docId} — skip embedding`,
+      );
+      return;
+    }
+
+    // 2. Embed bản tóm tắt (vừa hiển thị summary, vừa phục vụ semantic search).
+    await this.embeddingService.createEmbedding({
+      text: summaryText,
       contextId: data.docId,
       contextType: 'file',
       service: 'document',
       userId: data.userId,
+      messageId: data.messageId,
       replaceOld: true,
     });
+
+    // 3. Báo cho chat service re-fetch message + broadcast MSGUPSERT qua redis
+    //    adapter để bong bóng tin nhắn cập nhật summary realtime, không phải chờ
+    //    người dùng tải lại tin nhắn.
+    if (data.messageId) {
+      await Utils.dispatchEventKafka(
+        this.kafkaClient,
+        KafkaEvent.FILE_SUMMARY_READY,
+        { messageId: data.messageId },
+      );
+    }
   }
 
   @GrpcMethod('AIService', 'SearchMessages')

--- a/apps/ai/src/embedding.service.ts
+++ b/apps/ai/src/embedding.service.ts
@@ -296,6 +296,9 @@ Trả về MỘT đối tượng JSON DUY NHẤT như định dạng trên.
       messageId: string;
       createdAt: Date;
       score: number;
+      // Phạm vi (scope) của kết quả: 'room' = tin nhắn chat, 'file' = tệp
+      // đính kèm, 'doc' = tài liệu. FE dùng để hiển thị nguồn của hit.
+      contextType?: string;
     };
     const roomObjectId = Utils.convertToObjectIdMongoose(roomId);
 
@@ -342,6 +345,7 @@ Trả về MỘT đối tượng JSON DUY NHẤT như định dạng trên.
             _id: 0,
             text: 1,
             contextId: 1,
+            contextType: 1,
             messageId: 1,
             createdAt: 1,
             score: { $meta: 'vectorSearchScore' },
@@ -383,7 +387,7 @@ Trả về MỘT đối tượng JSON DUY NHẤT như định dạng trên.
                   { contextType: 'doc', contextId: { $in: docIds } },
                 ],
               })
-              .select('text contextId messageId createdAt vector')
+              .select('text contextId contextType messageId createdAt vector')
               .lean()
               .exec();
 
@@ -399,7 +403,7 @@ Trả về MỘT đối tượng JSON DUY NHẤT như định dạng trên.
         this.embedModel
           .find(keywordQuery)
           .limit(limit)
-          .select('-_id text contextId messageId createdAt')
+          .select('-_id text contextId contextType messageId createdAt')
           .lean()
           .exec()
           .then((docs) => {
@@ -516,6 +520,8 @@ Trả về MỘT đối tượng JSON DUY NHẤT như định dạng trên.
       return docs.map((d) => ({
         text: d.msg_content ?? '',
         contextId: String(d.msg_roomId),
+        // Hit từ Messages collection = tin nhắn chat → scope 'room'.
+        contextType: 'room',
         messageId: String(d._id),
         createdAt: d.createdAt,
         // Lower than vector hits (≥0) and lower than embedding-keyword hits

--- a/apps/chat/src/handle-chat/handle-chat.controller.ts
+++ b/apps/chat/src/handle-chat/handle-chat.controller.ts
@@ -68,6 +68,23 @@ export class HandleChatController {
     }
   }
 
+  /**
+   * AI vừa tóm tắt xong file đính kèm. Re-fetch message (pipeline đã join
+   * summary mới) rồi broadcast MSGUPSERT để FE cập nhật bong bóng realtime.
+   */
+  @MessagePattern(KafkaEvent.FILE_SUMMARY_READY)
+  async onFileSummaryReady(@Payload() data: { messageId: string }) {
+    try {
+      await this.hdChat.broadcastFileSummary(data.messageId);
+    } catch (err) {
+      this.logger.error(
+        `[FILE_SUMMARY_READY] broadcast failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
   @GrpcMethod('ChatService', 'GetOneMsg')
   async GetOneMsg(@Body() payload: { userId: string; msgId: string }) {
     this.logger.log('[gRPC] GetOneMsg called with payload:', payload);

--- a/apps/chat/src/handle-chat/handle-chat.service.ts
+++ b/apps/chat/src/handle-chat/handle-chat.service.ts
@@ -146,6 +146,30 @@ export class HandleChatService {
   }
 
   /**
+   * Re-fetch một message (pipeline đã join summary mới từ aiembeddings) rồi
+   * broadcast MSGUPSERT để FE cập nhật bong bóng realtime sau khi AI tóm tắt
+   * xong file đính kèm. Bắn thẳng qua Redis adapter tới room channel — clients
+   * join roomId lúc connect/mở phòng (xem rooms.service `room:update`).
+   * No-op khi message không tồn tại. Không ném lỗi (side-effect phụ).
+   */
+  async broadcastFileSummary(messageId: string): Promise<void> {
+    if (!messageId) return;
+    const msg = await this.messageModel.aggregate(
+      buildMessageDetailPipeline(messageId),
+    );
+    const doc = msg?.[0] as Record<string, any> | undefined;
+    if (!doc) return;
+    const roomId = doc.roomId ? String(doc.roomId) : '';
+    if (!roomId) return;
+    this.emitter.broadcastTo(
+      '/chat',
+      roomId,
+      socketEvent.MSGUPSERT,
+      this.serializeRoomEvent(doc),
+    );
+  }
+
+  /**
    * Catch-up `message.updated` (fat) cho TOÀN member của phòng + gắn `seq` vào
    * `msg` để live (gateway broadcast) dùng CHUNG seq với catch-up. Dùng cho
    * react / pin / recall — các thay đổi message hiển thị cho mọi người.

--- a/libs/dto/src/enum.type.ts
+++ b/libs/dto/src/enum.type.ts
@@ -73,6 +73,9 @@ export enum KafkaEvent {
   // Chat — ghi outbox change-feed (catch-up sync). Chat tự consume rồi bulkWrite
   // per-recipient vào UserChangeEvents. Xem plan/DONG_BO_EVENT_SYNC.md.
   OUTBOX_APPEND = 'chat.outboxAppend',
+  // Chat — AI đã tóm tắt xong file đính kèm. Chat consume rồi re-fetch message
+  // và broadcast MSGUPSERT để bong bóng tin nhắn cập nhật summary realtime.
+  FILE_SUMMARY_READY = 'chat.fileSummaryReady',
 
   // Notification & Auth
   SEND_OTP = 'send_otp',

--- a/libs/grpc/ai.proto
+++ b/libs/grpc/ai.proto
@@ -98,6 +98,8 @@ message SearchResult {
   string contextId = 2;
   double score = 3;
   string messageId = 4;
+  // Phạm vi (scope) của kết quả: 'room' = tin nhắn, 'file' = tệp, 'doc' = tài liệu.
+  string contextType = 5;
 }
 
 message SuggestRepliesRequest {


### PR DESCRIPTION
## Vấn đề
1. **Tóm tắt file không hoạt động:** `processFileEmbedding` nhét thẳng `fileUrl` làm text embedding → pipeline `getMsg` đọc ra "summary" chính là cái link, nên FE chỉ thấy link, AI không tóm tắt được.
2. **Summary không realtime:** sau khi tóm tắt xong không đẩy xuống client → chỉ thấy summary khi tải lại tin nhắn.
3. **Tìm kiếm tin nhắn không hiện scope:** `searchSimilarMessages` không trả `contextType` (room/file/doc) → FE không biết kết quả từ tin nhắn / tệp / tài liệu.

## Thay đổi
- **`apps/ai/ai.controller.ts`** — `processFileEmbedding`: tải file + gọi `summaryDocument('file_url')` để tạo tóm tắt THẬT, embed nội dung tóm tắt. Tóm tắt rỗng thì bỏ qua, **không** lưu link làm summary nữa.
- **Realtime push:** AI emit Kafka `FILE_SUMMARY_READY` → `apps/chat` consume → re-fetch message qua `buildMessageDetailPipeline` (đã join summary mới) → `broadcastTo('/chat', roomId, MSGUPSERT, msg)` qua redis adapter. Tái dùng đúng event MSGUPSERT FE đã xử lý → bong bóng tin nhắn cập nhật ngay, không cần FE đổi.
- **Search scope:** `searchSimilarMessages` trả thêm `contextType` ở mọi nhánh (vector / keyword / message fallback); thêm `contextType` vào `ai.proto` `SearchResult`.

## Files
- `apps/ai/src/ai.controller.ts`, `apps/ai/src/embedding.service.ts`
- `apps/chat/src/handle-chat/handle-chat.controller.ts`, `handle-chat.service.ts`
- `libs/dto/src/enum.type.ts`, `libs/grpc/ai.proto`

## Lưu ý
- FE cần render `contextType` ở danh sách kết quả tìm kiếm (làm ở PR FE riêng).
- `searchSimilarDocuments` (path không có roomId) chưa gắn `contextType='doc'` — bổ sung sau nếu cần.

🤖 Generated with [Claude Code](https://claude.com/claude-code)