### PR TITLE
feat(chat): realtime room upsert to member client rooms

### DIFF
--- a/apps/chat/src/rooms/rooms.service.ts
+++ b/apps/chat/src/rooms/rooms.service.ts
@@ -99,6 +99,28 @@ export class RoomsService {
   }
 
   /**
+   * Realtime room upsert — bắn thẳng qua Redis adapter tới room cá nhân
+   * (ROOM_CLIENT) của TỪNG member. Khác `emitRoomUpserted` (change-feed,
+   * chỉ thấy khi reload): cái này để client ĐANG online thấy room mới /
+   * member list thay đổi NGAY, kể cả member vừa được add (chưa join kênh
+   * roomId). FE handler fetch lại room theo từng user + join kênh roomId.
+   * `members` phải có field `id` (ULID usr_id) — đúng shape room_members.
+   */
+  private notifyRoomUpsertRealtime(
+    roomCustomId: string,
+    members: Array<{ id?: string }>,
+  ): void {
+    if (!roomCustomId) return;
+    const clientRooms = Array.from(
+      new Set((members ?? []).map((m) => m?.id).filter(Boolean) as string[]),
+    ).map((id) => this.key.ROOM_CLIENT(id));
+    if (!clientRooms.length) return;
+    this.emitter.broadcastTo('/chat', clientRooms, socketEvent.ROOMUPSERT, {
+      roomId: roomCustomId,
+    });
+  }
+
+  /**
    * Catch-up `room.removed` (thin) — client xoá room + messages khỏi cache. Dùng
    * khi user bị kick / rời / phòng bị xoá. No-op khi thiếu recipient.
    */
@@ -1320,6 +1342,9 @@ export class RoomsService {
         members: members,
       },
     });
+    // Realtime: member đang online (gồm người vừa được tạo nhóm cùng) thấy
+    // room mới ngay, không cần reload.
+    this.notifyRoomUpsertRealtime(room_id, members);
     return Response.success(result, 'Tạo phòng thành công');
   }
 
@@ -1863,6 +1888,9 @@ export class RoomsService {
         members: roomMember,
       },
     });
+    // Realtime: member cũ cập nhật member list, member MỚI thấy room ngay
+    // (roomMember đã gồm cả người vừa thêm, mỗi phần tử có `.id` = ULID).
+    this.notifyRoomUpsertRealtime(roomId, roomMember);
 
     return Response.success(
       { members: roomMember, roomId },


### PR DESCRIPTION
## Vấn đề
Khi tạo nhóm hoặc thêm thành viên, **member được thêm không nhận được thông báo realtime** về room đó — phải reload mới thấy. Trước đây chỉ có change-feed (`emitRoomUpserted`) là cơ chế catch-up khi mở lại app, không phải realtime.

## Nguyên nhân
- Room mới: chưa member nào join kênh socket `roomId` → broadcast tới kênh `roomId` không tới ai.
- Thêm member: member cũ ở trong kênh `roomId`, nhưng member MỚI thì chưa join → không nhận gì realtime.

## Giải pháp (dùng Redis adapter)
Thêm helper `notifyRoomUpsertRealtime()` bắn thẳng event `room:upsert` qua `RemoteSocketEmitter` (Redis adapter) tới **room cá nhân `ROOM_CLIENT(usr_id)` của từng member** — room này luôn được join lúc connect nên không phụ thuộc trạng thái join `roomId`. Tái dùng đúng pattern đã có ở `handle-chat.service.ts` (emit MSGUPSERT tới member client rooms).

Gọi ở `rooms.service.ts`:
- `create()` — sau khi tạo nhóm (notify toàn member, gồm creator).
- `addMemberInRoom()` — notify toàn member (member cũ cập nhật list, member mới thấy room).

Change-feed cũ giữ nguyên (catch-up cho user offline).

## FE đi kèm
FE thêm handler `room:upsert` → fetch lại room theo từng user + `emit('join', {roomId})` để member mới nhận tin nhắn realtime tiếp theo (PR FE riêng).

🤖 Generated with [Claude Code](https://claude.com/claude-code)