### PR TITLE
perf(chat): remove triplicated FlashcardDecks/TodoProjects lookups in getMsg

### DIFF
--- a/apps/chat/src/handle-chat/Pipeline/getMsg.ts
+++ b/apps/chat/src/handle-chat/Pipeline/getMsg.ts
@@ -636,50 +636,6 @@ export function buildMessageCorePipeline(userId: string): PipelineStage[] {
     },
     { $addFields: { todoProjectDoc: { $first: '$todoProjectDoc' } } },
 
-    /** 7.1b) Flashcard Deck */
-    {
-      $lookup: {
-        from: 'FlashcardDecks',
-        localField: 'desk_id',
-        foreignField: '_id',
-        as: 'deskDoc',
-      },
-    },
-    { $addFields: { deskDoc: { $first: '$deskDoc' } } },
-
-    /** 7.1c) Todo project */
-    {
-      $lookup: {
-        from: 'TodoProjects',
-        localField: 'todo_project_id',
-        foreignField: '_id',
-        as: 'todoProjectDoc',
-      },
-    },
-    { $addFields: { todoProjectDoc: { $first: '$todoProjectDoc' } } },
-
-    /** 7.1b) Flashcard Deck */
-    {
-      $lookup: {
-        from: 'FlashcardDecks',
-        localField: 'desk_id',
-        foreignField: '_id',
-        as: 'deskDoc',
-      },
-    },
-    { $addFields: { deskDoc: { $first: '$deskDoc' } } },
-
-    /** 7.1c) Todo project */
-    {
-      $lookup: {
-        from: 'TodoProjects',
-        localField: 'todo_project_id',
-        foreignField: '_id',
-        as: 'todoProjectDoc',
-      },
-    },
-    { $addFields: { todoProjectDoc: { $first: '$todoProjectDoc' } } },
-
     /** 7.2) Room event (for system messages) */
     ...roomEventLookupStages(),
 


### PR DESCRIPTION
## Vấn đề
`buildMessageCorePipeline` (đường đọc danh sách tin nhắn) lookup `FlashcardDecks` và `TodoProjects` **3 lần y hệt nhau** (getMsg.ts ~617-681), mỗi lần ghi đè cùng field `deskDoc`/`todoProjectDoc`. 2 lần sau là thao tác thừa hoàn toàn.

## Thay đổi
Bỏ 2 block lặp → còn 1 lookup mỗi collection. Loại 4 `$lookup` khỏi pipeline.

## Vì sao an toàn (không sửa FE)
Output pipeline **byte-identical** (lookup lặp chỉ ghi đè cùng giá trị) → payload trả FE không đổi. Zero rủi ro.

Phạm vi: đường **đọc** (getMsg list). Đường **gửi** (`buildMessageDetailPipeline`) không có dup này — sẽ xử lý riêng (xem phân tích tính khả thi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)