### PR TITLE
perf(kafka): partition tail topics + key MESSAGE_PERSISTED by roomId

### DIFF
--- a/apps/chat/src/handle-chat/handle-chat.service.ts
+++ b/apps/chat/src/handle-chat/handle-chat.service.ts
@@ -368,6 +368,10 @@ export class HandleChatService {
         serializedMsg,
         changeSeq,
       },
+      // key=roomMongoId → mọi tin cùng room về cùng partition: consumer tail
+      // (RoomsState/unread/last_message) xử lý ĐÚNG THỨ TỰ trong room dù
+      // MESSAGE_PERSISTED đã tăng lên nhiều partition.
+      finInfo._id.toString(),
     );
 
     return Response.success(

--- a/libs/helpers/utils.ts
+++ b/libs/helpers/utils.ts
@@ -267,6 +267,15 @@ class Utils {
         },
         consumer: kafkaConfig.consumer,
         producer: kafkaConfig.producer,
+        // Cho phép 1 instance xử lý nhiều partition SONG SONG (mặc định
+        // kafkajs = 1 = tuần tự). Cần thiết để việc tăng partition thực sự
+        // tăng throughput khi chạy ít instance. Thứ tự TRONG mỗi partition vẫn
+        // được giữ → topic keyed theo room không bị đảo.
+        run: {
+          partitionsConsumedConcurrently: Number(
+            process.env.KAFKA_PARTITIONS_CONCURRENCY ?? 3,
+          ),
+        },
       },
     });
 
@@ -300,6 +309,7 @@ class Utils {
     client: ClientKafka,
     pattern: string,
     data: Record<string, unknown> = {},
+    key?: string,
   ): Promise<
     ReturnType<typeof Response.success> | ReturnType<typeof Response.error>
   > {
@@ -318,7 +328,11 @@ class Utils {
       );
     }
     try {
-      await client.emit(pattern, data).toPromise();
+      // Có key → produce dạng { key, value } để Kafka phân partition theo key
+      // (cùng key = cùng partition, giữ thứ tự). NestJS serializer nhận shape
+      // này; consumer @Payload vẫn nhận đúng `value`. Không key → giữ nguyên.
+      const message = key ? { key, value: data } : data;
+      await client.emit(pattern, message).toPromise();
     } catch (error) {
       const errorMessage =
         error && typeof error === 'object' && 'message' in error

--- a/libs/kafka/kafka-admin.service.ts
+++ b/libs/kafka/kafka-admin.service.ts
@@ -63,6 +63,46 @@ export class KafkaAdminService implements OnModuleInit {
         this.logger.log('✅ All topics already exist');
       }
 
+      // Topic đã tồn tại từ trước KHÔNG được createTopics cập nhật partition.
+      // Kafka chỉ cho TĂNG partition (không giảm) → gọi createPartitions cho
+      // topic nào đang ít hơn cấu hình. An toàn & idempotent: bỏ qua nếu đã đủ.
+      try {
+        const wantMultiPartition = topics.filter(
+          (t) => existingTopics.includes(t.topic) && t.numPartitions > 1,
+        );
+        if (wantMultiPartition.length > 0) {
+          const meta = await admin.fetchTopicMetadata({
+            topics: wantMultiPartition.map((t) => t.topic),
+          });
+          const currentCount = new Map(
+            meta.topics.map((t) => [t.name, t.partitions.length]),
+          );
+          const toGrow = wantMultiPartition.filter(
+            (t) => (currentCount.get(t.topic) ?? 1) < t.numPartitions,
+          );
+          if (toGrow.length > 0) {
+            this.logger.log(
+              `Increasing partitions: ${toGrow
+                .map((t) => `${t.topic}->${t.numPartitions}`)
+                .join(', ')}`,
+            );
+            await admin.createPartitions({
+              topicPartitions: toGrow.map((t) => ({
+                topic: t.topic,
+                count: t.numPartitions,
+              })),
+            });
+            this.logger.log('✅ Kafka partitions increased');
+          }
+        }
+      } catch (err) {
+        this.logger.warn(
+          `⚠️  Increase partitions skipped: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+
       await admin.disconnect();
     } catch (error) {
       this.logger.error('❌ Error creating topics', error);

--- a/libs/kafka/kafka.topic.ts
+++ b/libs/kafka/kafka.topic.ts
@@ -1,7 +1,31 @@
 import { KafkaEvent } from '@app/dto';
 
+/**
+ * Số partition cho các topic tail lưu lượng cao → cho phép consumer xử lý
+ * song song (nhiều instance, hoặc `partitionsConsumedConcurrently` trong 1
+ * instance). Topic KHÔNG liệt kê giữ mặc định 1 partition.
+ *
+ * Lưu ý ordering: tăng partition = message rải nhiều partition. Topic cần giữ
+ * thứ tự theo room PHẢI produce kèm key=roomId (cùng room → cùng partition) —
+ * xem `MESSAGE_PERSISTED` ở handle-chat.service. Các topic dưới đây không keyed
+ * đều là tail độc lập theo từng item (embedding / push / summary), xử lý lệch
+ * thứ tự vô hại. `OUTBOX_APPEND` (change-feed theo seq) cố ý GIỮ 1 partition.
+ */
+const PARTITIONS_BY_TOPIC: Partial<Record<KafkaEvent, number>> = {
+  [KafkaEvent.MESSAGE_PERSISTED]: 6, // keyed=roomId → giữ thứ tự trong room
+  [KafkaEvent.AI_CHAT_MSG_EMBEDDING]: 3,
+  [KafkaEvent.AI_DOC_EMBEDDING]: 3,
+  [KafkaEvent.AI_PROCESS_FILE_EMBEDDING]: 3,
+  [KafkaEvent.PUSH_NOTIFICATION]: 3,
+  [KafkaEvent.PUSH_NOTIFICATION_USERS]: 3,
+  [KafkaEvent.FILE_SUMMARY_READY]: 3,
+};
+
+const DEFAULT_PARTITIONS = Number(process.env.KAFKA_DEFAULT_PARTITIONS ?? 1);
+
 export const topics = Object.values(KafkaEvent).map((topicName) => ({
   topic: topicName,
-  numPartitions: 1,
+  numPartitions:
+    PARTITIONS_BY_TOPIC[topicName as KafkaEvent] ?? DEFAULT_PARTITIONS,
   replicationFactor: -1, // Sử dụng default của broker
 }));


### PR DESCRIPTION
## Vấn đề
Mọi Kafka topic tạo với `numPartitions: 1` (`kafka.topic.ts`). Tail event (MESSAGE_PERSISTED, embedding, notification, summary) bị xếp hàng 1 partition → consumer không xử lý song song khi burst.

## Thay đổi
**1. Partition theo topic** (`kafka.topic.ts`): map riêng — `MESSAGE_PERSISTED=6`, embedding/push/summary=3; topic khác giữ 1. `OUTBOX_APPEND` **cố ý giữ 1** (change-feed dựa seq, không tách partition).

**2. ALTER topic đã tồn tại** (`kafka-admin.service.ts`): `createTopics` chỉ tạo topic **mới** nên đổi config không áp dụng cho topic cũ. Thêm `createPartitions` tăng partition cho topic đang ít hơn cấu hình (Kafka chỉ cho **tăng**; idempotent, bỏ qua nếu đã đủ; lỗi không chặn startup).

**3. Key=roomId cho topic nhạy thứ tự**: `dispatchEventKafka` thêm param `key` → produce `{ key, value }` (đúng API NestJS serializer, consumer `@Payload` vẫn nhận `value`). `MESSAGE_PERSISTED` produce **key=roomMongoId** → mọi tin cùng room về **cùng partition** → tail (RoomsState/unread/last_message) **giữ đúng thứ tự** dù nhiều partition.

**4. Consumer song song**: bật `partitionsConsumedConcurrently` (env `KAFKA_PARTITIONS_CONCURRENCY`, default 3) để 1 instance xử lý nhiều partition cùng lúc. Thứ tự **trong từng partition** vẫn giữ → topic keyed không bị đảo.

## An toàn
- Không đụng FE.
- Topic không keyed (embedding/push/summary) là tail độc lập theo từng item → lệch thứ tự vô hại.
- Topic nhạy thứ tự theo room (MESSAGE_PERSISTED) được keyed nên giữ ordering.
- `tsc` toàn repo sạch.

Đi kèm chuỗi tối ưu chat hot path: PR #108 (dedup lookup), PR #110 (fast-path payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)