### PR TITLE
perf(chat): don't block ack on MESSAGE_PERSISTED Kafka emit (fire-and-forget tail)

### DIFF
--- a/apps/chat/src/handle-chat/handle-chat.service.ts
+++ b/apps/chat/src/handle-chat/handle-chat.service.ts
@@ -365,7 +365,10 @@ export class HandleChatService {
       .filter((i) => i.user_id.toString() !== userInfo._id.toString())
       .map((i) => i.user_id.toString());
 
-    await this.utils.dispatchEventKafka(
+    // KHÔNG await: realtime đã broadcast ở trên, ack không nên chờ Kafka tail.
+    // Tail (RoomsState/unread/last_message) do consumer MESSAGE_PERSISTED xử lý
+    // bất đồng bộ; await ở đây chỉ kéo độ trễ broker vào ack. Fire-and-forget.
+    void this.utils.dispatchEventKafka(
       this.chatClient,
       KafkaEvent.MESSAGE_PERSISTED,
       {
@@ -391,7 +394,15 @@ export class HandleChatService {
       // (RoomsState/unread/last_message) xử lý ĐÚNG THỨ TỰ trong room dù
       // MESSAGE_PERSISTED đã tăng lên nhiều partition.
       finInfo._id.toString(),
-    );
+    ).catch((err) => {
+      // dispatchEventKafka tự nuốt lỗi (trả Response.error, không throw);
+      // .catch chỉ phòng hờ tránh unhandled rejection.
+      this.log.warn(
+        `[MESSAGE_PERSISTED] dispatch failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
 
     return Response.success(
       {


### PR DESCRIPTION
## Vấn đề
Trên send path, sau khi đã broadcast realtime (`MSGUPSERT`), code vẫn `await dispatchEventKafka(MESSAGE_PERSISTED)` rồi mới trả ack. Nếu Kafka/broker chậm → **ack bị kéo chậm theo**, dù người gửi đã thấy tin nhắn realtime.

## Thay đổi
`await` → **fire-and-forget** (`void ... .catch()`). Ack trả ngay sau broadcast; tail (RoomsState/unread/last_message) do consumer `MESSAGE_PERSISTED` xử lý bất đồng bộ như cũ.

## An toàn
- Reliability **không đổi**: `dispatchEventKafka` vốn tự nuốt lỗi (trả `Response.error`, không throw) và giá trị trả về **vốn đã bị bỏ qua** — nên trước hay sau, emit lỗi đều không fail ack. Chỉ khác là không còn *chờ*.
- `.catch` phòng hờ unhandled rejection.
- Không đụng FE. `tsc` chat sạch.

Đây là điểm nghẽn còn lại trên send path sau fast-path (#110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)