### PR TITLE
perf(search): add indexes for AIEmbedding/Attachment/Document semantic-search filters

### DIFF
--- a/libs/db/src/mongo/model/AIEmbedding.model.ts
+++ b/libs/db/src/mongo/model/AIEmbedding.model.ts
@@ -27,8 +27,9 @@ export class AIEmbedding {
   @Prop({ index: true }) // Index để tìm nhanh lịch sử của user
   userId?: string;
 
-  // Metadata để filter (Hybrid Search)
-  @Prop({ index: true })
+  // Metadata để filter (Hybrid Search). Index đơn bỏ đi vì đã có compound
+  // { contextType, contextId } bên dưới (prefix phủ luôn query chỉ theo contextType).
+  @Prop()
   contextType?: AIEmbeddingContextType; // 'room' | ...
 
   @Prop({ type: Types.ObjectId, default: null })
@@ -39,6 +40,11 @@ export class AIEmbedding {
 }
 
 export const AIEmbeddingSchema = SchemaFactory.createForClass(AIEmbedding);
+
+// Search semantic lọc embedding theo contextType + contextId ($in) — đặc biệt
+// ở fallback cosine/keyword (find({ $or: [{contextType, contextId}, ...] })).
+// Compound index phục vụ cả query chỉ theo contextType (prefix).
+AIEmbeddingSchema.index({ contextType: 1, contextId: 1 });
 
 export default {
   name: 'AIEmbedding',

--- a/libs/db/src/mongo/model/Attachment.model.ts
+++ b/libs/db/src/mongo/model/Attachment.model.ts
@@ -106,6 +106,9 @@ export class Attachment {
 
 export const AttachmentSchema = SchemaFactory.createForClass(Attachment);
 
+// Search semantic lấy danh sách file của room: find({ room_id }).distinct('_id').
+AttachmentSchema.index({ room_id: 1 });
+
 export default {
   name: 'Attachment',
   schema: AttachmentSchema,

--- a/libs/db/src/mongo/model/Document.model.ts
+++ b/libs/db/src/mongo/model/Document.model.ts
@@ -106,6 +106,9 @@ export class Document {
 
 export const DocumentSchema = SchemaFactory.createForClass(Document);
 
+// Search semantic lấy danh sách doc của room: find({ roomIds }).distinct('_id').
+DocumentSchema.index({ roomIds: 1 });
+
 export default {
   name: 'Document',
   schema: DocumentSchema,


### PR DESCRIPTION
## Vấn đề
`embedding.service.searchSimilarMessages` lọc dữ liệu theo các field **chưa có index** → chậm khi room nhiều file/doc/embedding:
- `Attachment.find({ room_id }).distinct('_id')` — `room_id` chưa index.
- `Document.find({ roomIds }).distinct('_id')` — `roomIds` chưa index.
- Fallback cosine/keyword: `AIEmbedding.find({ $or: [{contextType, contextId}, ...] })` — `contextId` chưa index.

## Thay đổi (chỉ thêm index)
- **AIEmbedding**: `{ contextType: 1, contextId: 1 }` (compound). Bỏ index đơn `contextType` cũ vì compound prefix đã phủ query chỉ theo `contextType` → tránh index trùng tốn write.
- **Attachment**: `{ room_id: 1 }`.
- **Document**: `{ roomIds: 1 }` (cùng hàm search, user chỉ nêu Attachment nhưng đây là cùng nút thắt).

## An toàn
- Chỉ thêm index, không đổi logic/shape. Không đụng FE. `tsc` toàn repo sạch.
- Mongo build index nền (background) lần deploy đầu; index nhỏ (không đụng field `vector`).

Đi kèm #118 (bỏ await Kafka tail khỏi ack). Khuyến nghị load test lại burst text + burst attachment sau khi merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)