### PR TITLE
perf(rooms): cap GetRooms page size to bound heavy per-room enrich

### DIFF
--- a/apps/chat/src/rooms/rooms.service.ts
+++ b/apps/chat/src/rooms/rooms.service.ts
@@ -1910,13 +1910,23 @@ export class RoomsService {
     const matchType = type && type !== 'all' ? { room_type: type } : {};
     const objectId = this.utils.convertToObjectIdMongoose(userId);
 
+    // Cap page size: handlePipeline enrich nặng (RoomEvents/last_message/
+    // MessageReads/pinned/Friendship) cho TỪNG phòng trong trang. Ổn ở ~20,
+    // nhưng nếu FE truyền limit lớn sẽ enrich hàng trăm phòng → nghẽn. Chặn
+    // trần để bảo vệ hot path; FE muốn nhiều hơn thì phân trang tiếp.
+    const MAX_ROOM_PAGE = Number(process.env.MAX_ROOM_PAGE ?? 50);
+    const pageLimit = Math.min(
+      Math.max(Number(limit) || 20, 1),
+      MAX_ROOM_PAGE,
+    );
+
     // PHÂN TRANG TRƯỚC (pha A nhẹ) → cắt còn ~limit phòng → ENRICH SAU (pha B
     // nặng = handlePipeline) chỉ trên trang. Lọc tên-rỗng + search `q` nằm trong
     // pha A (trước skip/limit) nên page size đúng và search chạy trên toàn tập.
     const listRooms = await this.roomModel.aggregate([
       ...this.buildRoomPaginateStages(objectId, { matchType, q }),
       { $skip: Number(offset || 0) },
-      { $limit: Number(limit || 20) },
+      { $limit: pageLimit },
       // dọn field tạm của pha A trước khi enrich (handlePipeline tự dựng lại
       // name/_lastTs/... và $project quyết định shape cuối — không đổi).
       { $unset: ['_pg_state', '_pg_lastTs', '_pg_other', '_pg_otherUser', '_pg_name'] },


### PR DESCRIPTION
## Vấn đề
`GetRooms` enrich mỗi phòng trong trang bằng `handlePipeline` (lookup RoomEvents / last_message / MessageReads / pinned_messages / Friendship). `$limit` lấy thẳng `limit` FE truyền, **không chặn trần** → nếu FE tăng `limit` (vd 500) sẽ enrich hàng trăm phòng → nghẽn (#3). Ổn ở limit 20 hiện tại.

## Giải pháp (nhỏ, đúng trọng tâm — không refactor pipeline)
Cap page size: `pageLimit = min(max(limit||20, 1), MAX_ROOM_PAGE)`, `MAX_ROOM_PAGE=50` (env `MAX_ROOM_PAGE`).
- limit ≤ 50: **hành vi không đổi**.
- limit lớn: bị chặn ở 50 → FE phân trang tiếp bằng `offset` (chuẩn cap page size).

YAGNI: pipeline đang "ổn ở limit 20" nên không đụng; chỉ bound input để hot path không bị thổi phồng.

## An toàn
Không đụng FE (FE đang dùng limit 20). `tsc` chat sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)