### PR TITLE
fix(chat): hydrate desk/todoProject in detail pipelines (realtime flashcard/todo messages)

### DIFF
--- a/apps/chat/src/handle-chat/Pipeline/getMsg.ts
+++ b/apps/chat/src/handle-chat/Pipeline/getMsg.ts
@@ -996,6 +996,28 @@ export function buildMessageDetailPipeline(msgId: string): PipelineStage[] {
       },
     },
 
+    /** 7.1b) Flashcard Deck */
+    {
+      $lookup: {
+        from: 'FlashcardDecks',
+        localField: 'desk_id',
+        foreignField: '_id',
+        as: 'deskDoc',
+      },
+    },
+    { $addFields: { deskDoc: { $first: '$deskDoc' } } },
+
+    /** 7.1c) Todo project */
+    {
+      $lookup: {
+        from: 'TodoProjects',
+        localField: 'todo_project_id',
+        foreignField: '_id',
+        as: 'todoProjectDoc',
+      },
+    },
+    { $addFields: { todoProjectDoc: { $first: '$todoProjectDoc' } } },
+
     /** 7.2) Room event (for system messages) */
     ...roomEventLookupStages(),
 
@@ -1347,6 +1369,28 @@ export function buildMessagesDetailPipeline(msgIds: string[]): PipelineStage[] {
         quizDoc: { $first: '$quizDoc' },
       },
     },
+
+    /** 7.1b) Flashcard Deck */
+    {
+      $lookup: {
+        from: 'FlashcardDecks',
+        localField: 'desk_id',
+        foreignField: '_id',
+        as: 'deskDoc',
+      },
+    },
+    { $addFields: { deskDoc: { $first: '$deskDoc' } } },
+
+    /** 7.1c) Todo project */
+    {
+      $lookup: {
+        from: 'TodoProjects',
+        localField: 'todo_project_id',
+        foreignField: '_id',
+        as: 'todoProjectDoc',
+      },
+    },
+    { $addFields: { todoProjectDoc: { $first: '$todoProjectDoc' } } },
 
     /** 7.2) Room event (for system messages) */
     ...roomEventLookupStages(),


### PR DESCRIPTION
## Triệu chứng
Tin chia sẻ **dự án (todo_project)** gửi realtime: nút **'Tham gia dự án' bị disable** ở người nhận. Tương tự tin **flashcard** không render card. **Reload thì đúng.**

## Nguyên nhân (bug CÓ SẴN, không phải do dedup #108)
`buildMessageDetailPipeline` và `buildMessagesDetailPipeline` `$project` ra `desk`/`todoProject` (qua `buildFlashcardDeckProjection`/`buildTodoProjectProjection`) nhưng **không có `$lookup` FlashcardDecks/TodoProjects** → `$deskDoc`/`$todoProjectDoc` undefined → cả hai luôn **null**.

Chỉ `buildMessageCorePipeline` (dùng khi load danh sách/reload) mới lookup → nên reload có dữ liệu, còn realtime (MSGUPSERT dùng **detail** pipeline) thì null.

FE (`MessageItem`): `type==='flashcard' && msg.desk`, `type==='todo_project'` cần `todoProject.project_id` (nút bật) → null ⇒ disable/không render.

Đã xác minh bằng git: diff #108 chỉ chạm `buildMessageCorePipeline` (`@@ -636,50 +636,6 @@`); trước #108 detail pipeline **đã không** có lookup. Bug có từ `4ee2c6e` (feat flashcard/todo: thêm lookup vào core, quên 2 detail pipeline).

## Fix
Thêm `$lookup` FlashcardDecks + TodoProjects (+ `$first`) vào **cả 2** detail pipeline, đúng như core. Projection sẵn có nên shape khớp core → **realtime = reload**, FE không phải đổi. `quiz` vốn đã có lookup nên không ảnh hưởng.

`tsc` chat sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)