### PR TITLE
fix(learning): entity lookups accept Mongo _id (quiz submit/open, todo join/open)

### DIFF
--- a/apps/chat/src/handle-chat/Pipeline/getMsg.ts
+++ b/apps/chat/src/handle-chat/Pipeline/getMsg.ts
@@ -156,6 +156,9 @@ function buildTodoProjectProjection() {
     $cond: [
       { $ifNull: ['$todoProjectDoc', false] },
       {
+        // Mongo _id (quy chuẩn id) — đồng bộ với quiz/flashcard projection,
+        // để FE gửi _id khi join (addProjectMember accept cả _id lẫn project_id).
+        id: { $toString: '$todoProjectDoc._id' },
         project_id: '$todoProjectDoc.project_id',
         project_name: '$todoProjectDoc.project_name',
         project_description: '$todoProjectDoc.project_description',

--- a/apps/learning/src/quizz/quizz.service.ts
+++ b/apps/learning/src/quizz/quizz.service.ts
@@ -19,6 +19,17 @@ export class QuizzService {
     @InjectModel(Message.name) private readonly messageModel: Model<Message>,
   ) {}
 
+  /**
+   * Filter tra quiz chấp nhận CẢ Mongo `_id` (quy chuẩn) lẫn `quiz_id` custom
+   * (tương thích dữ liệu/FE cũ). FE chat ưu tiên gửi `_id` nên nếu chỉ match
+   * quiz_id sẽ "not found" lúc nộp bài. Cùng pattern addProjectMember bên todo.
+   */
+  private byQuizId(quiz_id: string): Record<string, any> {
+    return Types.ObjectId.isValid(quiz_id)
+      ? { $or: [{ quiz_id }, { _id: new Types.ObjectId(quiz_id) }] }
+      : { quiz_id };
+  }
+
   async createQuizz(data: CreateQuizzDto & { quiz_createdBy: string }) {
     try {
       // Convert string IDs to ObjectId
@@ -35,7 +46,7 @@ export class QuizzService {
   }
 
   async getQuizzById(quiz_id: string) {
-    const quiz = await this.quizModel.findOne({ quiz_id });
+    const quiz = await this.quizModel.findOne(this.byQuizId(quiz_id));
     if (!quiz) {
       return Response.error('Quiz not found', 404, 'NOT_FOUND');
     }
@@ -91,7 +102,7 @@ export class QuizzService {
 
   async updateQuizzById(quiz_id: string, data: UpdateQuizzDto) {
     try {
-      const quiz = await this.quizModel.findOneAndUpdate({ quiz_id }, data, {
+      const quiz = await this.quizModel.findOneAndUpdate(this.byQuizId(quiz_id), data, {
         new: true,
       });
       if (!quiz) {
@@ -104,7 +115,7 @@ export class QuizzService {
   }
 
   async deleteQuizzById(quiz_id: string) {
-    const quiz = await this.quizModel.findOneAndDelete({ quiz_id });
+    const quiz = await this.quizModel.findOneAndDelete(this.byQuizId(quiz_id));
     if (!quiz) {
       return Response.error('Quiz not found', 404, 'NOT_FOUND');
     }
@@ -205,7 +216,7 @@ export class QuizzService {
 
   async submitQuizz(quiz_id: string, answer: AnswerSubmitDto) {
     try {
-      const quiz = await this.quizModel.findOne({ quiz_id });
+      const quiz = await this.quizModel.findOne(this.byQuizId(quiz_id));
       if (!quiz) {
         return Response.error('Quiz not found', 404, 'NOT_FOUND');
       }

--- a/apps/learning/src/todo/todo-project.service.ts
+++ b/apps/learning/src/todo/todo-project.service.ts
@@ -94,16 +94,23 @@ export class TodoProjectService {
   }
 
   async getProjectById(project_id: string, userId?: string) {
-    const filter: Record<string, any> = { project_id };
+    // Chấp nhận CẢ Mongo _id (quy chuẩn) lẫn project_id custom. Gộp điều kiện
+    // id và điều kiện quyền bằng $and để 2 nhóm $or không đè nhau.
+    const idOr = Types.ObjectId.isValid(project_id)
+      ? [{ project_id }, { _id: new Types.ObjectId(project_id) }]
+      : [{ project_id }];
+    const and: Record<string, any>[] = [{ $or: idOr }];
     if (userId && Types.ObjectId.isValid(userId)) {
       const userObjectId = new Types.ObjectId(userId);
-      filter.$or = [
-        { project_createdBy: userObjectId },
-        { project_members: userObjectId },
-      ];
+      and.push({
+        $or: [
+          { project_createdBy: userObjectId },
+          { project_members: userObjectId },
+        ],
+      });
     }
 
-    const project = await this.todoProjectModel.findOne(filter).lean();
+    const project = await this.todoProjectModel.findOne({ $and: and }).lean();
     if (!project) {
       return Response.error('Project not found', 404, 'NOT_FOUND');
     }

--- a/libs/grpc/chat.proto
+++ b/libs/grpc/chat.proto
@@ -726,6 +726,7 @@ message TodoProjectCore {
   string createdAt = 9;
   string updatedAt = 10;
   repeated string project_members = 11;
+  string id = 12; // Mongo _id (quy chuẩn id) — đồng bộ QuizCore/FlashcardDeckCore
 }
 message FlashcardDeckCore {
   string id = 1;


### PR DESCRIPTION
## Triệu chứng (user báo)
- Gửi **quiz** → bấm **nộp bài** → "không tìm thấy".
- Gửi **dự án (todo)** → bấm **tham gia** → "không tìm thấy dự án".
- Mở trang quiz/todo từ tin nhắn → "dữ liệu sai lệch / không truy cập được".

## Nguyên nhân
FE chat ưu tiên gửi **Mongo `_id`** (vd `quiz._id ?? quiz.quiz_id`), nhưng nhiều lookup BE chỉ match **custom id** (`quiz_id`/`project_id`) → mismatch → not found. (Chỉ thị: "quy chuẩn dùng mongo id hết".)

## Fix (BE-only, accept cả `_id` lẫn custom id)
- `quizz.service`: helper `byQuizId()` (= pattern `addProjectMember`) áp cho **get/update/delete/submit**; `getResults` vốn đã accept-both.
- `todo getProjectById`: accept cả `_id` lẫn `project_id` (`$and` gộp điều kiện id + quyền). `addProjectMember` (join) vốn đã accept-both.
- `getMsg buildTodoProjectProjection`: expose `id` (=`_id`); `chat.proto TodoProjectCore` thêm `string id = 12` (đồng bộ QuizCore/FlashcardDeckCore — nếu thiếu, gRPC reload sẽ rớt field).

## An toàn
Accept-both nên FE gửi id nào cũng chạy → **không cần sửa FE**, không phát sinh lỗi mới. `tsc` learning + chat sạch.

> Lưu ý: lỗi **mở tài liệu (open doc) bị 'truy cập bị từ chối'** là nguyên nhân KHÁC (doc.roomIds cập nhật bất đồng bộ qua tail MESSAGE_PERSISTED→SHARE_DOC_FOR_ROOM → race "DB chưa cập nhật") — chưa nằm trong PR này.

🤖 Generated with [Claude Code](https://claude.com/claude-code)