### PR TITLE
fix(chat): grant doc room access synchronously on share (no access-denied race)

### DIFF
--- a/apps/chat/src/handle-chat/handle-chat.service.ts
+++ b/apps/chat/src/handle-chat/handle-chat.service.ts
@@ -305,6 +305,32 @@ export class HandleChatService {
       throw new BadRequestException('không tạo được tin nhắn');
     }
 
+    // Chia sẻ tài liệu vào hội thoại: cấp quyền cho room NGAY (đồng bộ) TRƯỚC
+    // khi broadcast. Trước đây roomIds được set qua tail Kafka (MESSAGE_PERSISTED
+    // → SHARE_DOC_FOR_ROOM → filesystem) nên người nhận bấm sớm bị "truy cập bị
+    // từ chối" (DB chưa kịp cập nhật). Chat ghi thẳng documentModel (cùng Mongo).
+    // Match kèm ownerId → chỉ owner share được (non-owner no-op, giữ semantics cũ).
+    if (documentId) {
+      try {
+        await this.documentModel.updateOne(
+          {
+            _id: this.utils.convertToObjectIdMongoose(documentId),
+            ownerId: userInfo._id,
+          },
+          {
+            $addToSet: { roomIds: finInfo._id },
+            $set: { updatedAt: new Date() },
+          },
+        );
+      } catch (err) {
+        this.log.warn(
+          `[DOC_SHARE] cấp quyền room cho doc ${documentId} thất bại: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
     // Phát realtime NGAY khi payload đã đầy đủ — KHÔNG chờ tail side-effect
     // (Kafka embedding, push notification, bulkWrite unread) ở dưới, và KHÔNG
     // đi vòng gRPC response → gateway → emit. Bắn thẳng qua Redis adapter:
@@ -591,20 +617,8 @@ export class HandleChatService {
             ),
           ]
         : []),
-      ...(documentId
-        ? [
-            this.utils.dispatchEventKafka(
-              this.fileClient,
-              KafkaEvent.SHARE_DOC_FOR_ROOM,
-              {
-                roomId: roomCustomId,
-                userId: senderId,
-                docId: documentId,
-                messageId,
-              },
-            ),
-          ]
-        : []),
+      // SHARE_DOC_FOR_ROOM đã được làm ĐỒNG BỘ ở createMessage (cấp roomIds
+      // trước broadcast) để tránh race "truy cập bị từ chối". Bỏ emit tail.
       this.utils.dispatchEventKafka(
         this.notificationClient,
         KafkaEvent.PUSH_NOTIFICATION_USERS,


### PR DESCRIPTION
## Triệu chứng
Chia sẻ **tài liệu có sẵn** vào hội thoại → người khác bấm mở → **'truy cập bị từ chối'** (reload đôi khi đỡ).

## Nguyên nhân (race "DB chưa cập nhật")
Quyền mở doc dựa trên `doc.roomIds` (checkDocAccess: user là thành viên 1 room trong roomIds → cho phép). Nhưng `roomIds` chỉ được set qua **chuỗi bất đồng bộ**:
`createMessage` → broadcast tin NGAY → Kafka `MESSAGE_PERSISTED` → `handleMessagePersisted` → Kafka `SHARE_DOC_FOR_ROOM` → filesystem `shareDocumentForRoom` → `$addToSet roomIds`.
Người nhận thấy tin tức thì nhưng bấm trước khi chuỗi hoàn tất → `roomIds` chưa có room của họ → từ chối. (Doc tạo trực tiếp trong room không dính vì `createDoc` set roomIds ngay.)

## Fix (hướng A — đồng bộ tại nguồn)
Chat service **đã có `documentModel`** (cùng Mongo) → trong `createMessage`, khi có `documentId`, cập nhật `doc.roomIds` **đồng bộ TRƯỚC broadcast`**:
`updateOne({ _id: documentId, ownerId: sender }, { $addToSet: { roomIds: room._id } })`.
- Match kèm `ownerId` → giữ nguyên semantics **owner-only** (non-owner = no-op, không cấp quyền).
- Bỏ emit `SHARE_DOC_FOR_ROOM` ở tail (không còn cần). Lỗi cập nhật chỉ log, không chặn gửi tin.

→ Khi tin xuất hiện ở người nhận thì roomIds đã set xong → bấm mở không còn bị từ chối.

## An toàn
- Không sửa FE. `tsc` chat sạch.
- `filesystem @EventPattern(SHARE_DOC_FOR_ROOM)` giờ dead (không ai emit) — để nguyên, vô hại.

🤖 Generated with [Claude Code](https://claude.com/claude-code)