### PR TITLE
feat(chat): include replied-message attachments in reply payload (BE)

### DIFF
--- a/apps/chat/src/handle-chat/Pipeline/getMsg.ts
+++ b/apps/chat/src/handle-chat/Pipeline/getMsg.ts
@@ -459,6 +459,28 @@ export function buildMessageCorePipeline(userId: string): PipelineStage[] {
       },
     },
     { $set: { reply_sender: { $first: '$reply_sender' } } },
+    // Đính kèm (slim) của tin được reply → FE render thumbnail ảnh/file trong
+    // ô quote thay vì chỉ chữ "Ảnh", giúp biết đang reply tin nào (nhiều file).
+    {
+      $lookup: {
+        from: 'Attachments',
+        localField: 'reply_doc.attachment_ids',
+        foreignField: '_id',
+        pipeline: [
+          {
+            $project: {
+              _id: 1,
+              kind: 1,
+              url: 1,
+              name: 1,
+              thumbUrl: 1,
+              mimeType: 1,
+            },
+          },
+        ],
+        as: 'reply_attachments',
+      },
+    },
 
     /** 5.1) Reply hidden (All user) */
     {
@@ -679,6 +701,7 @@ export function buildMessageCorePipeline(userId: string): PipelineStage[] {
               type: '$reply_doc.msg_type',
               content: '$reply_doc.msg_content',
               createdAt: '$reply_doc.createdAt',
+              attachments: { $ifNull: ['$reply_attachments', []] },
               sender: {
                 _id: '$reply_sender._id',
                 name: '$reply_sender.usr_fullname',
@@ -841,6 +864,28 @@ export function buildMessageDetailPipeline(msgId: string): PipelineStage[] {
       },
     },
     { $set: { reply_sender: { $first: '$reply_sender' } } },
+    // Đính kèm (slim) của tin được reply → FE render thumbnail ảnh/file trong
+    // ô quote thay vì chỉ chữ "Ảnh", giúp biết đang reply tin nào (nhiều file).
+    {
+      $lookup: {
+        from: 'Attachments',
+        localField: 'reply_doc.attachment_ids',
+        foreignField: '_id',
+        pipeline: [
+          {
+            $project: {
+              _id: 1,
+              kind: 1,
+              url: 1,
+              name: 1,
+              thumbUrl: 1,
+              mimeType: 1,
+            },
+          },
+        ],
+        as: 'reply_attachments',
+      },
+    },
 
     /** 3.1) Reply hidden (All users) */
     {
@@ -1033,6 +1078,7 @@ export function buildMessageDetailPipeline(msgId: string): PipelineStage[] {
               type: '$reply_doc.msg_type',
               content: '$reply_doc.msg_content',
               createdAt: '$reply_doc.createdAt',
+              attachments: { $ifNull: ['$reply_attachments', []] },
               sender: {
                 _id: '$reply_sender._id',
                 name: '$reply_sender.usr_fullname',
@@ -1193,6 +1239,28 @@ export function buildMessagesDetailPipeline(msgIds: string[]): PipelineStage[] {
       },
     },
     { $set: { reply_sender: { $first: '$reply_sender' } } },
+    // Đính kèm (slim) của tin được reply → FE render thumbnail ảnh/file trong
+    // ô quote thay vì chỉ chữ "Ảnh", giúp biết đang reply tin nào (nhiều file).
+    {
+      $lookup: {
+        from: 'Attachments',
+        localField: 'reply_doc.attachment_ids',
+        foreignField: '_id',
+        pipeline: [
+          {
+            $project: {
+              _id: 1,
+              kind: 1,
+              url: 1,
+              name: 1,
+              thumbUrl: 1,
+              mimeType: 1,
+            },
+          },
+        ],
+        as: 'reply_attachments',
+      },
+    },
 
     /** 3.1) Reply hidden (All users) */
     {
@@ -1385,6 +1453,7 @@ export function buildMessagesDetailPipeline(msgIds: string[]): PipelineStage[] {
               type: '$reply_doc.msg_type',
               content: '$reply_doc.msg_content',
               createdAt: '$reply_doc.createdAt',
+              attachments: { $ifNull: ['$reply_attachments', []] },
               sender: {
                 _id: '$reply_sender._id',
                 name: '$reply_sender.usr_fullname',

--- a/libs/grpc/chat.proto
+++ b/libs/grpc/chat.proto
@@ -361,6 +361,7 @@ message MessageReply {
   ReplySender sender = 5;
   bool isDelete=7;
   repeated string hiddenBy=8;
+  repeated FilePreview attachments = 9; // đính kèm tin được reply (render thumbnail trong quote)
 }
 
 message ReadByUser {


### PR DESCRIPTION
## Mục tiêu
Ô **reply quote** trong bong bóng + thanh **"Đang trả lời"** chỉ hiện chữ "Ảnh"/"File" → khó biết đang reply tin nào khi tin có nhiều file. Cần render thumbnail ảnh/file của tin được reply.

## Phần BE (PR này)
`reply` projection (getMsg, cả 3 pipeline) trước chỉ có `type/content/sender` → thêm `attachments` (slim: `_id, kind, url, name, thumbUrl, mimeType`) bằng `$lookup Attachments` theo `reply_doc.attachment_ids`. Thêm `repeated FilePreview attachments` vào `MessageReply` proto (để path gRPC reload không rớt field).

## FE (làm riêng)
- Thanh soạn "Đang trả lời": `replyingTo` = full message (đã có `attachments`) → render thumbnail trực tiếp, không cần BE.
- Ô quote trong bong bóng: dùng `msg.reply.attachments` (từ PR này).

`tsc` chat sạch. Không ảnh hưởng FE hiện tại (chỉ thêm field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)