### PR TITLE
fix(chat): resolve flashcard desk_id to Mongo _id on share (deck not rendering)

### DIFF
--- a/apps/chat/src/handle-chat/handle-chat.service.ts
+++ b/apps/chat/src/handle-chat/handle-chat.service.ts
@@ -37,6 +37,7 @@ import {
   User,
   Document,
   Quiz,
+  FlashcardDeck,
 } from 'libs/db/src';
 import { Model, Types } from 'mongoose';
 import { RoomsService } from '../rooms/rooms.service';
@@ -112,6 +113,8 @@ export class HandleChatService {
     private readonly quizModel: Model<Quiz>,
     @InjectModel(TodoProject.name)
     private readonly todoProjectModel: Model<TodoProject>,
+    @InjectModel(FlashcardDeck.name)
+    private readonly flashcardDeckModel: Model<FlashcardDeck>,
     private readonly emitter: RemoteSocketEmitter,
     @Inject(SERVICES.CHAT)
     private readonly chatClient: ClientKafka,
@@ -275,9 +278,29 @@ export class HandleChatService {
         ? this.utils.convertToObjectIdMongoose(documentId)
         : null,
       quiz_id: quizId ? this.utils.convertToObjectIdMongoose(quizId) : null,
-      desk_id: desk_id ? this.utils.convertToObjectIdMongoose(desk_id) : null,
+      desk_id: null as Types.ObjectId | null,
       todo_project_id: null as Types.ObjectId | null,
     };
+
+    // desk_id: FE gửi deck_id custom (ULID) → convertToObjectIdMongoose sẽ ném
+    // lỗi / không khớp lookup (desk_id→_id) → tin flashcard không render. Resolve
+    // về Mongo _id, chấp nhận CẢ _id lẫn deck_id custom (giống todo_project).
+    if (desk_id) {
+      const deck = await this.flashcardDeckModel.findOne(
+        Types.ObjectId.isValid(desk_id) && desk_id.length === 24
+          ? {
+              $or: [
+                { _id: this.utils.convertToObjectIdMongoose(desk_id) },
+                { deck_id: desk_id },
+              ],
+            }
+          : { deck_id: desk_id },
+      );
+      if (!deck) {
+        throw new NotFoundException('Bộ thẻ không tồn tại');
+      }
+      updatePayload.desk_id = deck._id;
+    }
 
     if (todoProjectId) {
       const todoProject = await this.todoProjectModel.findOne({


### PR DESCRIPTION
## Triệu chứng
Tạo bộ thẻ ghi nhớ → bấm chia sẻ vào hội thoại → **tin flashcard không render**.

## Nguyên nhân (đúng nghi vấn 'chuẩn hoá mongo id')
- FE gửi `desk_id = args.desk?.deck_id` (**deck_id custom / ULID**), trong khi `quizId` gửi `args.quiz?._id` (mongo) và `todoProjectId` được createMessage **resolve** custom→_id.
- `createMessage` lại làm `desk_id: convertToObjectIdMongoose(desk_id)` → ULID 22-ký-tự không phải ObjectId hợp lệ → ném lỗi / lưu sai → message.desk_id không khớp lookup `desk_id → FlashcardDecks._id` → `desk` null → không render. (Trước #126 desk vốn không hydrate realtime nên lỗi bị che; sau #126 lookup chạy nhưng desk_id sai id nên vẫn null.)

## Fix (BE-only, mirror todo_project)
`createMessage` resolve `desk_id` qua `flashcardDeckModel` (đã đăng ký global) → `deck._id`, chấp nhận **CẢ** `_id` lẫn `deck_id` custom. Không cần sửa FE (đúng yêu cầu), thống nhất quy chuẩn lưu Mongo _id.

`tsc` chat sạch.

> Đã check master trước khi sửa (có #126/#129/#130 + các commit 'feat: update flashcard' của team).

🤖 Generated with [Claude Code](https://claude.com/claude-code)