### PR TITLE
fix(chat): shared doc accessible to all room members (drop owner gate)

### DIFF
--- a/apps/chat/src/handle-chat/handle-chat.service.ts
+++ b/apps/chat/src/handle-chat/handle-chat.service.ts
@@ -306,17 +306,14 @@ export class HandleChatService {
     }
 
     // Chia sẻ tài liệu vào hội thoại: cấp quyền cho room NGAY (đồng bộ) TRƯỚC
-    // khi broadcast. Trước đây roomIds được set qua tail Kafka (MESSAGE_PERSISTED
-    // → SHARE_DOC_FOR_ROOM → filesystem) nên người nhận bấm sớm bị "truy cập bị
-    // từ chối" (DB chưa kịp cập nhật). Chat ghi thẳng documentModel (cùng Mongo).
-    // Match kèm ownerId → chỉ owner share được (non-owner no-op, giữ semantics cũ).
+    // khi broadcast → MỌI THÀNH VIÊN room truy cập được (checkDocAccess cho phép
+    // nếu user thuộc 1 room trong doc.roomIds). KHÔNG gate theo owner: ai gửi
+    // được tin kèm documentId (đang có quyền tham chiếu tài liệu) thì chia sẻ
+    // vào room là hợp lệ. $addToSet idempotent nên gọi lại vô hại.
     if (documentId) {
       try {
         await this.documentModel.updateOne(
-          {
-            _id: this.utils.convertToObjectIdMongoose(documentId),
-            ownerId: userInfo._id,
-          },
+          { _id: this.utils.convertToObjectIdMongoose(documentId) },
           {
             $addToSet: { roomIds: finInfo._id },
             $set: { updatedAt: new Date() },


### PR DESCRIPTION
## Yêu cầu
Chia sẻ tài liệu vào đoạn chat → **chỉ cần thuộc room là truy cập được**.

## Vấn đề
PR #130 cấp `roomIds` chỉ khi `ownerId === sender` → nếu người chia sẻ không phải chủ tài liệu, room không được thêm vào `roomIds` → thành viên room bị từ chối.

## Fix
Bỏ điều kiện `ownerId` trong `createMessage`: khi có `documentId`, `$addToSet roomIds` cho room (idempotent). `checkDocAccess` vốn cấp quyền cho user thuộc 1 room trong `doc.roomIds` → mọi thành viên room truy cập được. Ai gửi được tin kèm documentId tức đang có quyền tham chiếu tài liệu nên chia sẻ là hợp lệ.

`tsc` chat sạch. Không sửa FE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)