### PR TITLE
feat(docs): upsert share role (change per-user editor/viewer permission)

### DIFF
--- a/apps/filesystem/src/documents/documents.service.ts
+++ b/apps/filesystem/src/documents/documents.service.ts
@@ -761,26 +761,31 @@ export class DocumentsService {
     );
 
     if (alreadyShared) {
-      throw new BadGatewayException('Tài liệu đã được chia sẻ với user này');
-    }
-
-    // Thêm user vào sharedWith
-    await this.docsModel.findByIdAndUpdate(
-      doc._id,
-      {
-        $push: {
-          sharedWith: {
-            userId: shareUserObjId,
-            role,
-            sharedAt: new Date(),
+      // Đã chia sẻ → CẬP NHẬT quyền (viewer/editor) thay vì báo lỗi, để owner
+      // đổi quyền từng người (nâng viewer→editor hoặc hạ editor→viewer).
+      await this.docsModel.updateOne(
+        { _id: doc._id, 'sharedWith.userId': shareUserObjId },
+        { $set: { 'sharedWith.$.role': role, updatedAt: new Date() } },
+      );
+    } else {
+      // Thêm user vào sharedWith
+      await this.docsModel.findByIdAndUpdate(
+        doc._id,
+        {
+          $push: {
+            sharedWith: {
+              userId: shareUserObjId,
+              role,
+              sharedAt: new Date(),
+            },
+          },
+          $set: {
+            updatedAt: new Date(),
           },
         },
-        $set: {
-          updatedAt: new Date(),
-        },
-      },
-      { new: true },
-    );
+        { new: true },
+      );
+    }
 
     const formattedDoc = await this.getFormattedDocumentById(docId);
 


### PR DESCRIPTION
## Yêu cầu
Cho phép đặt quyền **từng người** trên tài liệu: người này **chỉnh sửa**, người kia **chỉ xem** — và **đổi** được sau đó.

## Hiện trạng
Hạ tầng role đã có đầy đủ: `Document.sharedWith[{userId, role}]`, proto/gateway/service `ShareDocument(..., role)`, `checkDocAccess` dùng role cho `requireEdit`, FE ShareModal có Select viewer/editor khi thêm. **Thiếu duy nhất**: `shareDocument` **throw** nếu user đã được share → không đổi quyền được.

## Fix (BE)
`shareDocument` **upsert**: đã share → `$set sharedWith.$.role` (đổi quyền); chưa → `$push`. Gọi lại `ShareDocument` với role mới = đổi quyền.

`tsc` filesystem sạch.

> FE đi kèm (PR riêng): thêm dropdown role cho từng người ĐÃ share trong ShareModal (hiện chỉ hiện role dạng text + nút xoá) để gọi đổi quyền.

🤖 Generated with [Claude Code](https://claude.com/claude-code)