### PR TITLE
fix(flashcard): return Mongo _id as 'id' in deck get/create/duplicate

### DIFF
--- a/apps/learning/src/flashcard/flashcard.service.ts
+++ b/apps/learning/src/flashcard/flashcard.service.ts
@@ -136,7 +136,10 @@ export class FlashcardService {
           })),
         );
       }
-      return Response.success(deck);
+      return Response.success({
+        ...deck.toObject(),
+        id: deck._id.toString(), // trả mongo _id dưới field `id` (proto)
+      });
     } catch (error) {
       return Response.error(error.message, 400, 'Bad Request');
     }
@@ -156,6 +159,7 @@ export class FlashcardService {
     return Response.success({
       ...deck,
       _id: deck._id.toString(),
+      id: deck._id.toString(), // proto FlashcardDeckMetadata chỉ có field `id`
       total_cards,
       progress,
     });
@@ -371,7 +375,11 @@ export class FlashcardService {
         );
       }
 
-      return Response.success({ ...newDeck.toObject(), cloned_from: deck_id });
+      return Response.success({
+        ...newDeck.toObject(),
+        id: newDeck._id.toString(), // trả mongo _id dưới field `id` (proto)
+        cloned_from: deck_id,
+      });
     } catch (error) {
       return Response.error(error.message, 400, 'Bad Request');
     }


### PR DESCRIPTION
## Câu hỏi: `/api/learning/flashcard/deck/list` trả mongo id chưa?
**List thì CÓ** (đã map `id = _id.toString()`), nhưng **get/create/duplicate thì CHƯA**:
- proto `FlashcardDeckMetadata` chỉ có field `id` (= mongo _id), không có `_id`.
- `getFlashcardDeckById` trả `_id` → proto bỏ → `id` rỗng.
- `createFlashcardDeck`/`duplicateDeck` trả doc thô → `id` rỗng.

→ FE lấy deck từ get/create không có mongo id → chia sẻ vào hội thoại không có `desk_id` đúng.

## Fix
get/create/duplicate cùng trả `id = _id.toString()` (đồng bộ với list). Giờ mọi response deck đều có mongo id dưới field `id`.

`tsc` learning sạch. Đi kèm FE #84 (gửi desk_id khi share) — sau khi cả hai merge, share bộ thẻ render card chuẩn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)