### PR TITLE
fix(flashcard): shared deck shows cards (list by deck, not card_userId)

### DIFF
--- a/apps/learning/src/flashcard/flashcard.service.ts
+++ b/apps/learning/src/flashcard/flashcard.service.ts
@@ -58,18 +58,23 @@ export class FlashcardService {
   ) {
     try {
       const query: any = {};
-      if (userId) {
-        query.card_userId = new Types.ObjectId(userId);
-      }
       if (deckId) {
-        const desk = await this.flashcardDeckModel.findOne({ deck_id: deckId });
+        // Lọc theo BỘ THẺ → trả TẤT CẢ thẻ của bộ, KHÔNG lọc theo card_userId.
+        // Thẻ thuộc chủ bộ (card_userId=creator); nếu lọc thêm card_userId thì
+        // người khác xem bộ được chia sẻ sẽ thấy 0 thẻ. Quyền xem do bộ kiểm soát.
+        const desk = await this.flashcardDeckModel.findOne(
+          Types.ObjectId.isValid(deckId) && deckId.length === 24
+            ? { $or: [{ deck_id: deckId }, { _id: new Types.ObjectId(deckId) }] }
+            : { deck_id: deckId },
+        );
         if (!desk) {
           return Response.error('Flashcard deck not found', 404, 'NOT_FOUND');
         }
         query.card_deckId = desk._id;
+      } else if (userId) {
+        // Không kèm bộ thẻ → liệt kê thẻ rời của chính user.
+        query.card_userId = new Types.ObjectId(userId);
       }
-
-      console.log('query', query);
 
       const flashcards = await this.flashcardModel
         .find(query)


### PR DESCRIPTION
## Triệu chứng
Mở bộ thẻ được chia sẻ (`/flash-card/{deckId}`) → **không thẻ nào render** (dù bộ có thẻ).

## Nguyên nhân
`listFlashcards` lọc `card_userId = viewer` **AND** `card_deckId = deck._id`. Thẻ thuộc **chủ bộ** (card_userId=creator) → người xem khác chủ → 0 thẻ khớp.

## Fix
Khi có `deckId`: lọc theo **card_deckId** thôi (bỏ `card_userId`) → trả tất cả thẻ của bộ; quyền xem do bộ kiểm soát. `card_userId` chỉ áp khi liệt kê thẻ rời (không kèm deck). Deck lookup accept cả `deck_id` custom lẫn `_id`. Bỏ `console.log`.

`tsc` learning sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)