### PR TITLE
fix(chat): flashcard message card shows live card count (not stale deck_totalCards)

### DIFF
--- a/apps/chat/src/handle-chat/Pipeline/getMsg.ts
+++ b/apps/chat/src/handle-chat/Pipeline/getMsg.ts
@@ -126,8 +126,9 @@ function buildFlashcardDeckProjection() {
         deck_name: '$deskDoc.deck_name',
         deck_description: '$deskDoc.deck_description',
         deck_image: '$deskDoc.deck_image',
-        deck_totalCards: { $ifNull: ['$deskDoc.deck_totalCards', 0] },
-        total_cards: { $ifNull: ['$deskDoc.deck_totalCards', 0] },
+        // Dùng số đếm thật (deskCardCount) thay deck_totalCards lưu (hay lệch 0).
+        deck_totalCards: { $ifNull: ['$deskCardCount', 0] },
+        total_cards: { $ifNull: ['$deskCardCount', 0] },
         deck_level: { $ifNull: ['$deskDoc.deck_level', ''] },
         createdAt: toIso('$deskDoc.createdAt'),
         updatedAt: toIsoIfNotNull('$deskDoc.updatedAt'),
@@ -627,6 +628,25 @@ export function buildMessageCorePipeline(userId: string): PipelineStage[] {
       },
     },
     { $addFields: { deskDoc: { $first: '$deskDoc' } } },
+    // Đếm số thẻ THẬT của bộ (Flashcards theo card_deckId) — deck_totalCards
+    // lưu trên deck thường lệch (0 với bộ tạo trước khi maintain). card_deckId
+    // có index nên count rẻ; non-flashcard (deskDoc null) → count 0, bị bỏ qua.
+    {
+      $lookup: {
+        from: 'Flashcards',
+        let: { deckId: '$deskDoc._id' },
+        pipeline: [
+          { $match: { $expr: { $eq: ['$card_deckId', '$$deckId'] } } },
+          { $count: 'count' },
+        ],
+        as: 'deskCardCount',
+      },
+    },
+    {
+      $addFields: {
+        deskCardCount: { $ifNull: [{ $first: '$deskCardCount.count' }, 0] },
+      },
+    },
 
     /** 7.1c) Todo project */
     {
@@ -1009,6 +1029,25 @@ export function buildMessageDetailPipeline(msgId: string): PipelineStage[] {
       },
     },
     { $addFields: { deskDoc: { $first: '$deskDoc' } } },
+    // Đếm số thẻ THẬT của bộ (Flashcards theo card_deckId) — deck_totalCards
+    // lưu trên deck thường lệch (0 với bộ tạo trước khi maintain). card_deckId
+    // có index nên count rẻ; non-flashcard (deskDoc null) → count 0, bị bỏ qua.
+    {
+      $lookup: {
+        from: 'Flashcards',
+        let: { deckId: '$deskDoc._id' },
+        pipeline: [
+          { $match: { $expr: { $eq: ['$card_deckId', '$$deckId'] } } },
+          { $count: 'count' },
+        ],
+        as: 'deskCardCount',
+      },
+    },
+    {
+      $addFields: {
+        deskCardCount: { $ifNull: [{ $first: '$deskCardCount.count' }, 0] },
+      },
+    },
 
     /** 7.1c) Todo project */
     {
@@ -1383,6 +1422,25 @@ export function buildMessagesDetailPipeline(msgIds: string[]): PipelineStage[] {
       },
     },
     { $addFields: { deskDoc: { $first: '$deskDoc' } } },
+    // Đếm số thẻ THẬT của bộ (Flashcards theo card_deckId) — deck_totalCards
+    // lưu trên deck thường lệch (0 với bộ tạo trước khi maintain). card_deckId
+    // có index nên count rẻ; non-flashcard (deskDoc null) → count 0, bị bỏ qua.
+    {
+      $lookup: {
+        from: 'Flashcards',
+        let: { deckId: '$deskDoc._id' },
+        pipeline: [
+          { $match: { $expr: { $eq: ['$card_deckId', '$$deckId'] } } },
+          { $count: 'count' },
+        ],
+        as: 'deskCardCount',
+      },
+    },
+    {
+      $addFields: {
+        deskCardCount: { $ifNull: [{ $first: '$deskCardCount.count' }, 0] },
+      },
+    },
 
     /** 7.1c) Todo project */
     {


### PR DESCRIPTION
## Triệu chứng
Card bộ thẻ trong tin nhắn hiện **'0 thẻ'** dù bộ thực tế có thẻ (vd 20).

## Nguyên nhân
`buildFlashcardDeckProjection` lấy `deck_totalCards` lưu trên deck — field này **lệch 0** với các bộ tạo trước khi có maintain (#133), trong khi trang chi tiết deck hiển thị đúng vì tự `countDocuments`.

## Fix
Thêm `$lookup` đếm **Flashcards theo `card_deckId`** (đã có index) ở cả 3 message pipeline → projection dùng số đếm THẬT (`deskCardCount`) cho `deck_totalCards`/`total_cards`. Đúng cho **cả bộ cũ** (không cần backfill). Non-flashcard message (deskDoc null) → count 0, bị bỏ qua bởi `$cond`.

`tsc` chat sạch. Bổ sung cho #133 (maintain deck_totalCards) — projection giờ không phụ thuộc field lưu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)